### PR TITLE
Enhance card styling with larger boxes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -64,18 +64,31 @@ h1, h2, h3, h4 {
 /* Cards Layout */
 .qualifications, .work-cards {
     display: flex;
-    gap: 20px;
+    gap: 40px;
     flex-wrap: wrap;
     justify-content: center;
 }
 
 .card {
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 15px;
-    padding: 20px;
-    flex: 1;
-    min-width: 250px;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 20px;
+    padding: 40px;
+    flex: 1 1 320px;
+    min-width: 300px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(10px);
     transition: transform 0.3s ease;
+}
+
+.card h3,
+.card h4 {
+    font-size: 1.4rem;
+    margin-bottom: 15px;
+}
+
+.card p {
+    font-size: 1.1rem;
 }
 
 .card:hover {
@@ -84,11 +97,23 @@ h1, h2, h3, h4 {
 
 /* Project Cards */
 .projects .project-card {
-    background: rgba(255, 255, 255, 0.08);
-    margin: 20px 0;
-    padding: 20px;
-    border-radius: 15px;
+    background: rgba(255, 255, 255, 0.12);
+    margin: 30px 0;
+    padding: 40px;
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(10px);
     transition: transform 0.3s ease;
+}
+
+.projects .project-card h3 {
+    font-size: 1.5rem;
+    margin-bottom: 15px;
+}
+
+.projects .project-card p {
+    font-size: 1.1rem;
 }
 
 .projects .project-card:hover {


### PR DESCRIPTION
## Summary
- Increase gap and padding for qualification and work cards
- Add borders, shadows, and blur for polished card and project styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5f6f919483229a0be7f998b0345c