### PR TITLE
style: enlarge content boxes and hero image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -51,9 +51,19 @@ h1, h2, h3, h4 {
 }
 
 .hero-img img {
-    width: 280px;
-    border-radius: 20px;
+    width: 320px;
+    height: 320px;
+    object-fit: cover;
+    border-radius: 50%;
+    border: 4px solid #00ffcc;
     box-shadow: 0 8px 25px rgba(0, 255, 200, 0.3);
+}
+
+@media (max-width: 768px) {
+    .hero-img img {
+        width: 220px;
+        height: 220px;
+    }
 }
 
 /* Intro Section */
@@ -70,11 +80,13 @@ h1, h2, h3, h4 {
 }
 
 .card {
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 15px;
-    padding: 20px;
-    flex: 1;
-    min-width: 250px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 30px;
+    flex: 1 1 45%;
+    min-width: 300px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
     transition: transform 0.3s ease;
 }
 
@@ -84,10 +96,13 @@ h1, h2, h3, h4 {
 
 /* Project Cards */
 .projects .project-card {
-    background: rgba(255, 255, 255, 0.08);
-    margin: 20px 0;
-    padding: 20px;
-    border-radius: 15px;
+    background: rgba(255, 255, 255, 0.1);
+    margin: 30px auto;
+    padding: 30px;
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+    max-width: 800px;
     transition: transform 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- Enlarge content cards by increasing padding, width, and shadow for a more spacious feel
- Enhance project card styling with centered layout, borders, and larger dimensions
- Expand hero profile photo with circular crop, accent border, and responsive sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f64e5f35883228a95b4dac3c2a247